### PR TITLE
replace command to start app.js

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js",
+    "start": "nodemon app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": {


### PR DESCRIPTION
## Description
Replace in package.json the command to start app.js (node app.js) by nodemon app.js 

## Related Issue
Missing nodemon to start app.js #12

## Motivation and Context
Because the modification of source code is not taken into account.

## How Has This Been Tested?
Modify source code.
